### PR TITLE
[CSS] Fixes to UITextView+NIStyleable

### DIFF
--- a/src/css/src/UITextView+NIStyleable.m
+++ b/src/css/src/UITextView+NIStyleable.m
@@ -30,10 +30,7 @@ NI_FIX_CATEGORY_BUG(UITextView_NIStyleable)
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 -(void)applyStyleWithRuleSet:(NICSSRuleset*)ruleSet forPseudoClass:(NSString *)pseudo inDOM:(NIDOM*)dom
 {
-    if (ruleSet.hasTextKey) {
-        NIUserInterfaceString *nis = [[NIUserInterfaceString alloc] initWithKey:ruleSet.textKey];
-        [nis attach:self withSelector:@selector(setPlaceholder:)];
-    }
+    [self applyTextViewStyleWithRuleSet:ruleSet inDOM:dom];
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
- Fixes to the UITextView applyStyleWithRuleSet:forPseudoClass:inDOM: to apply more possible values in the ruleset.

This was originally a copy of UITextField+NIStyleable and the applyStyleWithRuleSet:forPseudoClass:inDOM: only applied the style to the placeholder text.
