### PR TITLE
[string] Don't show the localized key name for strings that have default...

### DIFF
--- a/src/css/src/NIUserInterfaceString.m
+++ b/src/css/src/NIUserInterfaceString.m
@@ -326,6 +326,9 @@ NIUserInterfaceStringResolver
       return overridden;
     }
   }
+  if (value == nil || [value isEqualToString:@""]) {
+    return @"";
+  }
   return NSLocalizedStringWithDefaultValue(key, nil, [NSBundle mainBundle], value, nil);
 }
 


### PR DESCRIPTION
... nil or empty values.
